### PR TITLE
aptos-tracer: implement one-shot rest trace command

### DIFF
--- a/aptos-move/aptos-tracer/src/main.rs
+++ b/aptos-move/aptos-tracer/src/main.rs
@@ -1,18 +1,22 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Result;
-use aptos_tracer::{DebuggerServerConfig, run_debugger_server};
+use anyhow::{Context, Result};
+use aptos_tracer::{run_debugger_server, DebuggerServerConfig, SyncAptosTracer};
 use aptos_rest_client::Client;
 use clap::{Parser, Subcommand};
+use std::collections::HashMap;
 use std::path::PathBuf;
 use url::Url;
-use std::collections::HashMap;
 
 #[derive(Subcommand)]
 pub enum Target {
     /// Use full node's rest api as query endpoint.
-    Rest { endpoint: String, txn_hash: String, chain_id: u8 },
+    Rest {
+        endpoint: String,
+        txn_hash: String,
+        chain_id: u16,
+    },
     /// Use a local db instance to serve as query endpoint.
     DB { path: PathBuf, listen_address: Option<String>, listen_port: Option<u16> },
     /// Use a full node's rest api as query endpoint and run as a server.
@@ -32,19 +36,27 @@ async fn main() -> Result<()> {
     aptos_logger::Logger::new().init();
     let args = Argument::parse();
     match args.target {
-        Target::Rest { endpoint, txn_hash, chain_id } => {
-            // let tracer = AptosTracer::rest_client(Client::new(Url::parse(&endpoint)?), args.sentio_endpoint)?;
-            // println!(
-            //     "{}",
-            //     serde_json::to_string_pretty(
-            //         &tracer
-            //         .trace_transaction(txn_hash, chain_id)
-            //         .await?)?
-            // );
-            // Ok(())
-            unimplemented!();
-        },
-        Target::DB { path,  listen_address, listen_port} => {
+        Target::Rest {
+            endpoint,
+            txn_hash,
+            chain_id,
+        } => {
+            let tracer = SyncAptosTracer::rest_client(
+                Client::new(Url::parse(&endpoint).context("invalid rest endpoint URL")?),
+                args.sentio_endpoint,
+            )?;
+            let hash = strip_hex_prefix(txn_hash.trim());
+            let trace = tracer
+                .trace_transaction(hash.to_owned(), chain_id)
+                .with_context(|| format!("failed to trace transaction {txn_hash}"))?;
+            println!("{}", serde_json::to_string_pretty(&trace)?);
+            Ok(())
+        }
+        Target::DB {
+            path,
+            listen_address,
+            listen_port,
+        } => {
             // run as a server if the target is DB
             let mut config = DebuggerServerConfig::default();
             config.set_db_path(path);
@@ -57,14 +69,18 @@ async fn main() -> Result<()> {
                 config.listen_port = port;
             }
             run_debugger_server(config).await
-        },
-        Target::ServerBasedOnRest { endpoints, listen_address, listen_port } => {
+        }
+        Target::ServerBasedOnRest {
+            endpoints,
+            listen_address,
+            listen_port,
+        } => {
             // run as a server if the target is DB
             let mut config = DebuggerServerConfig::default();
             config.set_use_db(false);
             config.set_sentio_endpoint(args.sentio_endpoint);
 
-            let mut endpoint_map: HashMap<u16, String> = HashMap::new(); 
+            let mut endpoint_map: HashMap<u16, String> = HashMap::new();
             let chain_to_endpoint: Vec<&str> = endpoints.split(',').collect();
             for i in chain_to_endpoint.iter() {
                 let t: Vec<&str> = i.split('=').collect();
@@ -78,8 +94,15 @@ async fn main() -> Result<()> {
                 config.listen_port = port;
             }
             run_debugger_server(config).await
-        },
+        }
     }
+}
+
+fn strip_hex_prefix(value: &str) -> &str {
+    value
+        .strip_prefix("0x")
+        .or_else(|| value.strip_prefix("0X"))
+        .unwrap_or(value)
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- implement the `Rest` CLI subcommand in `aptos-tracer` as a one-shot trace flow
- create a REST-backed `SyncAptosTracer`, run `trace_transaction`, and print pretty JSON output
- normalize tx hash input by stripping optional `0x`/`0X` prefix
- improve CLI error context for invalid endpoint URL and trace failures
- update `Rest` `chain_id` argument type from `u8` to `u16`

## Notes
- `Rest` mode performs a direct one-shot trace and exits (no debugger server lifecycle)
- server lifecycle behavior remains in `DB` and `ServerBasedOnRest` modes

## Validation
- targeted `cargo check` was started; long workspace build produced only existing warnings before being stopped