### PR TITLE
aptos-tracer: add one-shot REST trace and binary release CI

### DIFF
--- a/.github/workflows/aptos-tracer-release.yaml
+++ b/.github/workflows/aptos-tracer-release.yaml
@@ -1,0 +1,64 @@
+name: "Release aptos-tracer"
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        type: string
+        required: true
+        description: "The release tag to create. E.g. `aptos-tracer-v0.1.0`:"
+      source_git_ref_override:
+        type: string
+        required: false
+        description: "Use this to override the Git SHA1, branch name, or tag to build from."
+      dry_run:
+        type: boolean
+        required: false
+        default: true
+        description: "Dry run. If checked, binaries are built and uploaded as workflow artifacts only."
+      skip_checks:
+        type: boolean
+        required: false
+        default: false
+        description: "Skip version/tag checks."
+
+jobs:
+  build-linux-x86-64:
+    name: "Build Linux x86_64 binary"
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_git_ref_override || github.sha }}
+      - uses: ./.github/actions/cli-rust-setup
+      - name: Build aptos-tracer
+        run: scripts/tracer/build_tracer_release.sh "Linux" "${{ inputs.release_tag }}" "${{ inputs.skip_checks }}" "true"
+      - name: Upload Binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: tracer-builds-linux-x86-64
+          path: aptos-tracer-*.zip
+
+  release-binaries:
+    name: "Release binaries"
+    needs:
+      - build-linux-x86-64
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: "write"
+    if: ${{ inputs.dry_run == false }}
+    steps:
+      - name: Download prebuilt binaries
+        uses: actions/download-artifact@v4
+        with:
+          pattern: tracer-builds-*
+          merge-multiple: true
+      - name: Create GitHub Release
+        uses: marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0 # pin@v1.2.1
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "${{ inputs.release_tag }}"
+          prerelease: false
+          title: "${{ format('Aptos Tracer Release {0}', inputs.release_tag) }}"
+          files: |
+            aptos-tracer-*.zip

--- a/aptos-move/aptos-tracer/src/main.rs
+++ b/aptos-move/aptos-tracer/src/main.rs
@@ -1,18 +1,22 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Result;
-use aptos_tracer::{DebuggerServerConfig, run_debugger_server};
+use anyhow::{Context, Result};
+use aptos_tracer::{run_debugger_server, DebuggerServerConfig, SyncAptosTracer};
 use aptos_rest_client::Client;
 use clap::{Parser, Subcommand};
+use std::collections::HashMap;
 use std::path::PathBuf;
 use url::Url;
-use std::collections::HashMap;
 
 #[derive(Subcommand)]
 pub enum Target {
     /// Use full node's rest api as query endpoint.
-    Rest { endpoint: String, txn_hash: String, chain_id: u8 },
+    Rest {
+        endpoint: String,
+        txn_hash: String,
+        chain_id: u16,
+    },
     /// Use a local db instance to serve as query endpoint.
     DB { path: PathBuf, listen_address: Option<String>, listen_port: Option<u16> },
     /// Use a full node's rest api as query endpoint and run as a server.
@@ -32,19 +36,27 @@ async fn main() -> Result<()> {
     aptos_logger::Logger::new().init();
     let args = Argument::parse();
     match args.target {
-        Target::Rest { endpoint, txn_hash, chain_id } => {
-            // let tracer = AptosTracer::rest_client(Client::new(Url::parse(&endpoint)?), args.sentio_endpoint)?;
-            // println!(
-            //     "{}",
-            //     serde_json::to_string_pretty(
-            //         &tracer
-            //         .trace_transaction(txn_hash, chain_id)
-            //         .await?)?
-            // );
-            // Ok(())
-            unimplemented!();
-        },
-        Target::DB { path,  listen_address, listen_port} => {
+        Target::Rest {
+            endpoint,
+            txn_hash,
+            chain_id,
+        } => {
+            let tracer = SyncAptosTracer::rest_client(
+                Client::new(Url::parse(&endpoint).context("invalid rest endpoint URL")?),
+                args.sentio_endpoint,
+            )?;
+            let hash = strip_hex_prefix(txn_hash.trim());
+            let trace = tracer
+                .trace_transaction(hash.to_owned(), chain_id)
+                .with_context(|| format!("failed to trace transaction {txn_hash}"))?;
+            println!("{}", serde_json::to_string_pretty(&trace)?);
+            Ok(())
+        }
+        Target::DB {
+            path,
+            listen_address,
+            listen_port,
+        } => {
             // run as a server if the target is DB
             let mut config = DebuggerServerConfig::default();
             config.set_db_path(path);
@@ -57,14 +69,18 @@ async fn main() -> Result<()> {
                 config.listen_port = port;
             }
             run_debugger_server(config).await
-        },
-        Target::ServerBasedOnRest { endpoints, listen_address, listen_port } => {
+        }
+        Target::ServerBasedOnRest {
+            endpoints,
+            listen_address,
+            listen_port,
+        } => {
             // run as a server if the target is DB
             let mut config = DebuggerServerConfig::default();
             config.set_use_db(false);
             config.set_sentio_endpoint(args.sentio_endpoint);
 
-            let mut endpoint_map: HashMap<u16, String> = HashMap::new(); 
+            let mut endpoint_map: HashMap<u16, String> = HashMap::new();
             let chain_to_endpoint: Vec<&str> = endpoints.split(',').collect();
             for i in chain_to_endpoint.iter() {
                 let t: Vec<&str> = i.split('=').collect();
@@ -78,8 +94,15 @@ async fn main() -> Result<()> {
                 config.listen_port = port;
             }
             run_debugger_server(config).await
-        },
+        }
     }
+}
+
+fn strip_hex_prefix(value: &str) -> &str {
+    value
+        .strip_prefix("0x")
+        .or_else(|| value.strip_prefix("0X"))
+        .unwrap_or(value)
 }
 
 #[test]

--- a/scripts/tracer/build_tracer_release.sh
+++ b/scripts/tracer/build_tracer_release.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Copyright © Aptos Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+# Build and package a release binary for aptos-tracer.
+# Example:
+# scripts/tracer/build_tracer_release.sh Linux aptos-tracer-v0.1.0 false true
+
+set -euo pipefail
+
+NAME="aptos-tracer"
+CRATE_NAME="aptos-tracer"
+CARGO_PATH="aptos-move/aptos-tracer/Cargo.toml"
+PLATFORM_NAME="${1:-}"
+RELEASE_TAG="${2:-}"
+SKIP_CHECKS="${3:-false}"
+COMPATIBILITY_MODE="${4:-false}"
+RELEASE_REPO="${5:-${GITHUB_REPOSITORY:-sentioxyz/aptos-core}}"
+
+if [[ -z "$PLATFORM_NAME" || -z "$RELEASE_TAG" ]]; then
+  echo "Usage: $0 <platform_name> <release_tag> [skip_checks] [compatibility_mode] [release_repo]"
+  exit 1
+fi
+
+ARCH="$(uname -m)"
+OS="$(uname -s)"
+VERSION="$(sed -n '/^\w*version = /p' "$CARGO_PATH" | sed 's/^.*=[ ]*"//g' | sed 's/".*$//g')"
+
+if [[ "$SKIP_CHECKS" != "true" ]]; then
+  if ! [[ "$RELEASE_TAG" =~ ^aptos-tracer-v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+    echo "$RELEASE_TAG is malformed, must match '^aptos-tracer-v[0-9]+\\.[0-9]+\\.[0-9]+$'"
+    exit 2
+  fi
+
+  EXPECTED_VERSION="${BASH_REMATCH[1]}"
+  if [[ "$EXPECTED_VERSION" != "$VERSION" ]]; then
+    echo "Wanted to release for $EXPECTED_VERSION, but Cargo.toml says the version is $VERSION"
+    exit 3
+  fi
+
+  if curl -s --stderr /dev/null --output /dev/null --head -f "https://github.com/${RELEASE_REPO}/releases/download/${RELEASE_TAG}/${NAME}-${VERSION}-${PLATFORM_NAME}-${ARCH}.zip"; then
+    echo "${RELEASE_TAG} already exists with ${NAME}-${VERSION}-${PLATFORM_NAME}-${ARCH}.zip"
+    exit 4
+  fi
+else
+  echo "WARNING: Skipping version checks!"
+fi
+
+echo "Building $NAME $VERSION for ${OS}-${PLATFORM_NAME} on ${ARCH}"
+if [[ "$COMPATIBILITY_MODE" == "true" ]]; then
+  RUSTFLAGS="-C target-cpu=generic --cfg tokio_unstable -C target-feature=-sse4.2,-avx" cargo build --locked -p "$CRATE_NAME" --profile cli
+else
+  cargo build --locked -p "$CRATE_NAME" --profile cli
+fi
+
+cd target/cli
+
+ZIP_NAME="${NAME}-${VERSION}-${PLATFORM_NAME}-${ARCH}.zip"
+echo "Zipping release: ${ZIP_NAME}"
+zip "$ZIP_NAME" "$CRATE_NAME"
+mv "$ZIP_NAME" ../..


### PR DESCRIPTION
## Summary
- add one-shot `Rest` subcommand implementation for `aptos-tracer`
- add CI workflow to build and release `aptos-tracer` binary via `workflow_dispatch`
- add `scripts/tracer/build_tracer_release.sh` with tag/version checks and packaging

## Details
- new workflow: `.github/workflows/aptos-tracer-release.yaml`
- release artifacts: `aptos-tracer-<version>-Linux-<arch>.zip`
- release tags expected: `aptos-tracer-v<semver>` (unless checks are skipped)

## How to use (after merge)
1. Actions -> `Release aptos-tracer`
2. set `release_tag` (e.g. `aptos-tracer-v0.1.0`)
3. run once with `dry_run=true` to verify artifacts
4. run with `dry_run=false` to publish GitHub release
