### PR TITLE
ci: add aptos-tracer binary release workflow (Linux + macOS)

### DIFF
--- a/.github/workflows/aptos-tracer-release.yaml
+++ b/.github/workflows/aptos-tracer-release.yaml
@@ -1,0 +1,64 @@
+name: "Release aptos-tracer"
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        type: string
+        required: true
+        description: "The release tag to create. E.g. `aptos-tracer-v0.1.0`:"
+      source_git_ref_override:
+        type: string
+        required: false
+        description: "Use this to override the Git SHA1, branch name, or tag to build from."
+      dry_run:
+        type: boolean
+        required: false
+        default: true
+        description: "Dry run. If checked, binaries are built and uploaded as workflow artifacts only."
+      skip_checks:
+        type: boolean
+        required: false
+        default: false
+        description: "Skip version/tag checks."
+
+jobs:
+  build-linux-x86-64:
+    name: "Build Linux x86_64 binary"
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_git_ref_override || github.sha }}
+      - uses: ./.github/actions/cli-rust-setup
+      - name: Build aptos-tracer
+        run: scripts/tracer/build_tracer_release.sh "Linux" "${{ inputs.release_tag }}" "${{ inputs.skip_checks }}" "true"
+      - name: Upload Binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: tracer-builds-linux-x86-64
+          path: aptos-tracer-*.zip
+
+  release-binaries:
+    name: "Release binaries"
+    needs:
+      - build-linux-x86-64
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: "write"
+    if: ${{ inputs.dry_run == false }}
+    steps:
+      - name: Download prebuilt binaries
+        uses: actions/download-artifact@v4
+        with:
+          pattern: tracer-builds-*
+          merge-multiple: true
+      - name: Create GitHub Release
+        uses: marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0 # pin@v1.2.1
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "${{ inputs.release_tag }}"
+          prerelease: false
+          title: "${{ format('Aptos Tracer Release {0}', inputs.release_tag) }}"
+          files: |
+            aptos-tracer-*.zip

--- a/.github/workflows/aptos-tracer-release.yaml
+++ b/.github/workflows/aptos-tracer-release.yaml
@@ -39,10 +39,44 @@ jobs:
           name: tracer-builds-linux-x86-64
           path: aptos-tracer-*.zip
 
+  build-macos-x86-64:
+    name: "Build macOS x86_64 binary"
+    runs-on: macos-15-intel
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_git_ref_override || github.sha }}
+      - uses: ./.github/actions/cli-rust-setup
+      - name: Build aptos-tracer
+        run: scripts/tracer/build_tracer_release.sh "macOS" "${{ inputs.release_tag }}" "${{ inputs.skip_checks }}" "false"
+      - name: Upload Binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: tracer-builds-macos-x86-64
+          path: aptos-tracer-*.zip
+
+  build-macos-arm64:
+    name: "Build macOS ARM64 binary"
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_git_ref_override || github.sha }}
+      - uses: ./.github/actions/cli-rust-setup
+      - name: Build aptos-tracer
+        run: scripts/tracer/build_tracer_release.sh "macOS" "${{ inputs.release_tag }}" "${{ inputs.skip_checks }}" "false"
+      - name: Upload Binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: tracer-builds-macos-arm64
+          path: aptos-tracer-*.zip
+
   release-binaries:
     name: "Release binaries"
     needs:
       - build-linux-x86-64
+      - build-macos-x86-64
+      - build-macos-arm64
     runs-on: ubuntu-22.04
     permissions:
       contents: "write"

--- a/scripts/tracer/build_tracer_release.sh
+++ b/scripts/tracer/build_tracer_release.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Copyright © Aptos Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+# Build and package a release binary for aptos-tracer.
+# Example:
+# scripts/tracer/build_tracer_release.sh Linux aptos-tracer-v0.1.0 false true
+
+set -euo pipefail
+
+NAME="aptos-tracer"
+CRATE_NAME="aptos-tracer"
+CARGO_PATH="aptos-move/aptos-tracer/Cargo.toml"
+PLATFORM_NAME="${1:-}"
+RELEASE_TAG="${2:-}"
+SKIP_CHECKS="${3:-false}"
+COMPATIBILITY_MODE="${4:-false}"
+RELEASE_REPO="${5:-${GITHUB_REPOSITORY:-sentioxyz/aptos-core}}"
+
+if [[ -z "$PLATFORM_NAME" || -z "$RELEASE_TAG" ]]; then
+  echo "Usage: $0 <platform_name> <release_tag> [skip_checks] [compatibility_mode] [release_repo]"
+  exit 1
+fi
+
+ARCH="$(uname -m)"
+OS="$(uname -s)"
+VERSION="$(sed -n '/^\w*version = /p' "$CARGO_PATH" | sed 's/^.*=[ ]*"//g' | sed 's/".*$//g')"
+
+if [[ "$SKIP_CHECKS" != "true" ]]; then
+  if ! [[ "$RELEASE_TAG" =~ ^aptos-tracer-v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+    echo "$RELEASE_TAG is malformed, must match '^aptos-tracer-v[0-9]+\\.[0-9]+\\.[0-9]+$'"
+    exit 2
+  fi
+
+  EXPECTED_VERSION="${BASH_REMATCH[1]}"
+  if [[ "$EXPECTED_VERSION" != "$VERSION" ]]; then
+    echo "Wanted to release for $EXPECTED_VERSION, but Cargo.toml says the version is $VERSION"
+    exit 3
+  fi
+
+  if curl -s --stderr /dev/null --output /dev/null --head -f "https://github.com/${RELEASE_REPO}/releases/download/${RELEASE_TAG}/${NAME}-${VERSION}-${PLATFORM_NAME}-${ARCH}.zip"; then
+    echo "${RELEASE_TAG} already exists with ${NAME}-${VERSION}-${PLATFORM_NAME}-${ARCH}.zip"
+    exit 4
+  fi
+else
+  echo "WARNING: Skipping version checks!"
+fi
+
+echo "Building $NAME $VERSION for ${OS}-${PLATFORM_NAME} on ${ARCH}"
+if [[ "$COMPATIBILITY_MODE" == "true" ]]; then
+  RUSTFLAGS="-C target-cpu=generic --cfg tokio_unstable -C target-feature=-sse4.2,-avx" cargo build --locked -p "$CRATE_NAME" --profile cli
+else
+  cargo build --locked -p "$CRATE_NAME" --profile cli
+fi
+
+cd target/cli
+
+ZIP_NAME="${NAME}-${VERSION}-${PLATFORM_NAME}-${ARCH}.zip"
+echo "Zipping release: ${ZIP_NAME}"
+zip "$ZIP_NAME" "$CRATE_NAME"
+mv "$ZIP_NAME" ../..


### PR DESCRIPTION
## Summary
- add a dedicated `workflow_dispatch` release workflow for `aptos-tracer`
- add `scripts/tracer/build_tracer_release.sh` to build/package release zips with tag/version checks
- build release artifacts for Linux x86_64, macOS x86_64, and macOS ARM64
- publish assets to a GitHub release when `dry_run=false`

## Workflow
- file: `.github/workflows/aptos-tracer-release.yaml`
- inputs: `release_tag`, `source_git_ref_override`, `dry_run`, `skip_checks`
- expected tag format: `aptos-tracer-v<semver>` (unless checks are skipped)

## Notes
- this branch is based on latest `sentio/dev-2026-0210`
- tracer one-shot REST command is already in base branch (PR #12 merged)
